### PR TITLE
Fixes Scheduling Text Padding and Map Functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - gem install github-pages --no-rdoc --no-ri
 
 rvm:
-- 2.2
+- 2.3
 script: jekyll build
 
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -44,6 +44,14 @@
   margin-left: 15px;
 }
 
+.map-holder:before {
+  content: none;
+}
+
+.maps iframe{
+  pointer-events: none;
+}
+
 .tweets-feed {
   color: #FFFFFF;
   line-height: 25px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -32,6 +32,18 @@
   border: none;
 }
 
+.schedule-title {
+  margin-right: 20px;
+}
+
+.schedule-text {
+  margin-right: 15px;
+}
+
+.marker-pin {
+  margin-left: 15px;
+}
+
 .tweets-feed {
   color: #FFFFFF;
   line-height: 25px;

--- a/index.html
+++ b/index.html
@@ -1386,7 +1386,7 @@
                     </div>
                 </div>
             </div>
-            <div class="map-holder zoom-off col-md-6 col-sm-4">
+            <div class="map-holder zoom-off col-md-6 col-sm-4 maps">
                 <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=105.19409179687501%2C9.638661389766769%2C107.29248046875001%2C11.315787392354615&amp;layer=mapnik"></iframe>
             </div>
         </section>
@@ -1529,6 +1529,13 @@
                     // or you can do it on some other event
                 });
 
+                // disable mouse control on map unless clicked
+                $('.maps').click(function () {
+                    $('.maps iframe').css("pointer-events", "auto");
+                });
+                $(".maps").mouseleave(function () {
+                    $('.maps iframe').css("pointer-events", "none");
+                });
             });
             $('.map-holder').click(function () {
                 $(this).removeClass('zoom-off');


### PR DESCRIPTION
Adds in padding between the text, title, and marker pins to prevent overlapping from occurring.

![image](https://user-images.githubusercontent.com/8119928/47400731-81ad5580-d70c-11e8-91c1-f98858a01c15.png)

Also adds in functionality to the static map on the front and prevents users from scrolling into it and then getting stuck zooming in and out.

Fixes #172 and #174 